### PR TITLE
intake rotation PID control

### DIFF
--- a/src/main/java/frc/lib/drivers/uppermech/ConfiguredCANSparkMax.java
+++ b/src/main/java/frc/lib/drivers/uppermech/ConfiguredCANSparkMax.java
@@ -1,0 +1,13 @@
+package frc.lib.drivers.uppermech;
+
+import com.revrobotics.CANSparkMax;
+
+public class ConfiguredCANSparkMax extends CANSparkMax {
+    public ConfiguredCANSparkMax(int id, MotorType motorType, IdleMode idleMode, boolean inverted) {
+        super(id, motorType);
+        this.restoreFactoryDefaults();
+        this.setIdleMode(idleMode);
+        this.setInverted(inverted);
+        this.burnFlash();
+    }
+}

--- a/src/main/java/frc/lib/drivers/uppermech/PIDCANSparkMax.java
+++ b/src/main/java/frc/lib/drivers/uppermech/PIDCANSparkMax.java
@@ -5,11 +5,11 @@ import com.revrobotics.CANSparkMax;
 import frc.lib.structs.CANSparkPIDFConfig;
 
 public class PIDCANSparkMax extends CANSparkMax {
-    public PIDCANSparkMax(int deviceId, MotorType m, IdleMode mode, boolean isInverted,
+    public PIDCANSparkMax(int deviceId, MotorType motorType, IdleMode idleMode, boolean isInverted,
             CANSparkPIDFConfig sparkPidfConfig) {
-        super(deviceId, m);
+        super(deviceId, motorType);
         this.restoreFactoryDefaults();
-        this.setIdleMode(mode);
+        this.setIdleMode(idleMode);
         this.setInverted(isInverted);
         this.getPIDController().setOutputRange(sparkPidfConfig.kMinOutput, sparkPidfConfig.kMaxOutput);
         this.getPIDController().setP(sparkPidfConfig.kP);

--- a/src/main/java/frc/robot/commands/intake/RotateIntakeToAngle.java
+++ b/src/main/java/frc/robot/commands/intake/RotateIntakeToAngle.java
@@ -6,11 +6,8 @@ import frc.robot.subsystems.intake.IntakeRotation;
 
 public class RotateIntakeToAngle extends Command {
     private final double kAngle;
-    private double kDirection;
 
     private final IntakeRotation intakeRotation;
-
-    private boolean slowed = false;
 
     public RotateIntakeToAngle(IntakeRotation intakeRotation, double angle) {
         this.kAngle = angle;
@@ -20,9 +17,12 @@ public class RotateIntakeToAngle extends Command {
 
     @Override
     public void initialize() {
-        if (Math.abs(this.intakeRotation.getAngle() - this.kAngle) <= 5) {
-            this.end(false);
-        }
+        // uncomment if things go haywire when you try to set to a position it's already
+        // at/very close to
+
+        // if (Math.abs(this.intakeRotation.getAngle() - this.kAngle) <= 5) {
+        // this.end(false);
+        // }
     }
 
     @Override

--- a/src/main/java/frc/robot/commands/intake/RotateIntakeToAngle.java
+++ b/src/main/java/frc/robot/commands/intake/RotateIntakeToAngle.java
@@ -5,46 +5,36 @@ import frc.robot.constants.Constants;
 import frc.robot.subsystems.intake.IntakeRotation;
 
 public class RotateIntakeToAngle extends Command {
-    private final double kPosition;
+    private final double kAngle;
     private double kDirection;
 
-    private final IntakeRotation intake;
+    private final IntakeRotation intakeRotation;
 
     private boolean slowed = false;
 
-    public RotateIntakeToAngle(IntakeRotation intakeRotation, double position) {
-        this.kPosition = position;
-        this.intake = intakeRotation;
-        addRequirements(this.intake);
+    public RotateIntakeToAngle(IntakeRotation intakeRotation, double angle) {
+        this.kAngle = angle;
+        this.intakeRotation = intakeRotation;
+        addRequirements(this.intakeRotation);
     }
 
     @Override
     public void initialize() {
-        this.kDirection = this.intake.getEncoderAbsolutePosition() > kPosition
-                ? Constants.Intake.ROTATION_MOTOR_UP_DIRECTION
-                : Constants.Intake.ROTATION_MOTOR_DOWN_DIRECTION;
-        this.intake.setMotorVelocitySetpoint(3500 * this.kDirection);
-        // this.m_intake.setRotationAngleSetpoint(Constants.Intake.DOWN_DEGREES); //
-        // lower intake
     }
 
     @Override
     public void execute() {
-        // once it gets close enough to position, slow down to hone in on position
-        if (Math.abs(this.intake.getEncoderAbsolutePosition() - kPosition) <= 0.1 && !this.slowed) {
-            this.intake.setMotorVelocitySetpoint(250 * this.kDirection);
-            this.slowed = true;
-        }
+        this.intakeRotation.setAngle(this.kAngle);
     }
 
     @Override
     public boolean isFinished() {
-        return Math.abs(this.intake.getEncoderAbsolutePosition() - kPosition) <= 0.005;
+        return this.intakeRotation.atSetpoint();
     }
 
     @Override
     public void end(boolean interrupted) {
-        this.intake.stopMotor();
+        this.intakeRotation.stopMotor();
     }
 
     public static RotateIntakeToAngle createIntakeDownCommand(IntakeRotation intakeRotation) {
@@ -52,7 +42,7 @@ public class RotateIntakeToAngle extends Command {
     }
 
     public static RotateIntakeToAngle createIntakeUpCommand(IntakeRotation intakeRotation) {
-        return new RotateIntakeToAngle(intakeRotation, Constants.Intake.UP_ABSOLUTE_ENCODER_VALUE);
+        return new RotateIntakeToAngle(intakeRotation, Constants.Intake.UP_DEGREES);
     }
 
     public static RotateIntakeToAngle createIntakeStraightCommand(IntakeRotation intakeRotation) {

--- a/src/main/java/frc/robot/commands/intake/RotateIntakeToAngle.java
+++ b/src/main/java/frc/robot/commands/intake/RotateIntakeToAngle.java
@@ -20,6 +20,9 @@ public class RotateIntakeToAngle extends Command {
 
     @Override
     public void initialize() {
+        if (Math.abs(this.intakeRotation.getAngle() - this.kAngle) <= 5) {
+            this.end(false);
+        }
     }
 
     @Override
@@ -38,7 +41,7 @@ public class RotateIntakeToAngle extends Command {
     }
 
     public static RotateIntakeToAngle createIntakeDownCommand(IntakeRotation intakeRotation) {
-        return new RotateIntakeToAngle(intakeRotation, Constants.Intake.DOWN_ABSOLUTE_ENCODER_VALUE);
+        return new RotateIntakeToAngle(intakeRotation, Constants.Intake.DOWN_DEGREES);
     }
 
     public static RotateIntakeToAngle createIntakeUpCommand(IntakeRotation intakeRotation) {
@@ -46,6 +49,6 @@ public class RotateIntakeToAngle extends Command {
     }
 
     public static RotateIntakeToAngle createIntakeStraightCommand(IntakeRotation intakeRotation) {
-        return new RotateIntakeToAngle(intakeRotation, Constants.Intake.STRAIGHT_ABSOLUTE_ENCODER_VALUE);
+        return new RotateIntakeToAngle(intakeRotation, Constants.Intake.STRAIGHT_DEGREES);
     }
 }

--- a/src/main/java/frc/robot/commands/routines/IntakeNote.java
+++ b/src/main/java/frc/robot/commands/routines/IntakeNote.java
@@ -15,8 +15,9 @@ public class IntakeNote extends SequentialCommandGroup {
                                 // rotate intake down while running intake power motors until note gets detected
                                 RotateIntakeToAngle.createIntakeDownCommand(intakeRotationSubsystem)
                                                 .alongWith(new GrabNote(intakePowerSubsystem, colorSensorSubsystem)),
+                                // run intake power motors for a bit to ensure note gets positioned correctly
                                 Commands.waitSeconds(0.1),
-                                // rotate intake up
+                                // rotate intake back up
                                 RotateIntakeToAngle.createIntakeUpCommand(intakeRotationSubsystem));
         }
 }

--- a/src/main/java/frc/robot/commands/routines/IntakeNote.java
+++ b/src/main/java/frc/robot/commands/routines/IntakeNote.java
@@ -1,5 +1,6 @@
 package frc.robot.commands.routines;
 
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.commands.intake.GrabNote;
 import frc.robot.commands.intake.RotateIntakeToAngle;
@@ -8,14 +9,14 @@ import frc.robot.subsystems.intake.IntakePower;
 import frc.robot.subsystems.intake.IntakeRotation;
 
 public class IntakeNote extends SequentialCommandGroup {
-    public IntakeNote(IntakeRotation intakeRotationSubsystem, IntakePower intakePowerSubsystem,
-            ColorSensor colorSensorSubsystem) {
-        this.addCommands(
-                // rotate intake down while running intake power motors until note gets detected
-                RotateIntakeToAngle.createIntakeDownCommand(intakeRotationSubsystem)
-                        .alongWith(new GrabNote(intakePowerSubsystem, colorSensorSubsystem)),
-
-                // rotate intake up
-                RotateIntakeToAngle.createIntakeUpCommand(intakeRotationSubsystem));
-    }
+        public IntakeNote(IntakeRotation intakeRotationSubsystem, IntakePower intakePowerSubsystem,
+                        ColorSensor colorSensorSubsystem) {
+                this.addCommands(
+                                // rotate intake down while running intake power motors until note gets detected
+                                RotateIntakeToAngle.createIntakeDownCommand(intakeRotationSubsystem)
+                                                .alongWith(new GrabNote(intakePowerSubsystem, colorSensorSubsystem)),
+                                Commands.waitSeconds(0.1),
+                                // rotate intake up
+                                RotateIntakeToAngle.createIntakeUpCommand(intakeRotationSubsystem));
+        }
 }

--- a/src/main/java/frc/robot/constants/Constants.java
+++ b/src/main/java/frc/robot/constants/Constants.java
@@ -52,30 +52,25 @@ public final class Constants {
     public static final int ROTATION_THROUGH_BORE_ENCODER_DIO_PORT = 0;
     public static final int TOP_LIMIT_SWITCH_DIO_PORT = 4;
 
-    public static final double ENCODER_POSITION_OFFSET = 0.323;
+    public static final double ROTATION_THROUGH_BORE_ENCODER_POSITION_OFFSET = 0.323;
+    // the intake treats 0 degrees as the intake being up inside the robot, and
+    // moving out from the robot is + degrees
     public static final double UP_DEGREES = 0;
     public static final double STRAIGHT_DEGREES = 90;
     public static final double DOWN_DEGREES = 213;
 
-    // public static final int UP_DEGREES = 0;
-    // public static final int DOWN_DEGREES = 180;
-    public static final double ROTATION_MOTOR_UP_DIRECTION = 1.0;
-    public static final double ROTATION_MOTOR_DOWN_DIRECTION = -1.0;
     public static final double POWER_MOTOR_IN_DIRECTION = -1.0;
     public static final double POWER_MOTOR_OUT_DIRECTION = 1.0;
 
     public static final double POWER_MOTOR_MAX_RPM = MotorFreeSpeeds.NEO_BRUSHLESS;
-    public static final double ROTATION_MOTOR_GEAR_RATIO = 60.0 / 1.0;
-    public static final double ROTATION_POSITION_CONVERSION_FACTOR = 360.0 / ROTATION_MOTOR_GEAR_RATIO;
 
     public static final CANSparkPIDFConfig POWER_MOTOR_SPARK_PIDF_CONFIG = new CANSparkPIDFConfig(0.000006, 0, 0,
         0, -1, 1);
-    public static final CANSparkPIDFConfig ROTATION_MOTOR_SPARK_PIDF_CONFIG = new CANSparkPIDFConfig(0.000006, 0, 0,
-        0, -1, 1);
-    public static final PIDConfig ROTATION_MOTOR_PID_CONFIG = new PIDConfig(0.08 * 12.0, 0, 0);
+    public static final PIDConfig ROTATION_MOTOR_PID_CONFIG = new PIDConfig(0.08 * 12.0, 0, 0); // we tuned this
+    // slightly fudged kS value, but i had to account for there sometimes being
+    // gravity
     public static final FFConfig ROTATION_MOTOR_FF_CONFIG = new FFConfig(0.2);
     public static final FFConfig POWER_MOTOR_FF_CONFIG = new FFConfig(0.132, 12.0 / 5740.0);
-    // 5740
   }
 
   public static final class Shooter {
@@ -101,7 +96,7 @@ public final class Constants {
     public static final double MAX_RPM = MotorFreeSpeeds.NEO_BRUSHLESS;
 
     public static final CANSparkPIDFConfig LEFT_SPARK_PIDF_CONFIG = new CANSparkPIDFConfig(0.002, 0, 0, 0.0003, -1, 1);
-    public static final CANSparkPIDFConfig RIGHT_SPARK_PIDF_CONFIG = new CANSparkPIDFConfig(0.002, 0, 0, 0.0005, -1, 1);
+    public static final CANSparkPIDFConfig RIGHT_SPARK_PIDF_CONFIG = new CANSparkPIDFConfig(0.002, 0, 0, 0.0006, -1, 1);
   }
 
   public static final class Swerve {
@@ -152,9 +147,9 @@ public final class Constants {
     public static final int DRIVE_MOTOR_SMART_LIMIT = 45;
     public static final int ANGLE_MOTOR_SMART_LIMIT = 25;
 
+    // multiply by 12.0 because voltage control is used
     public static final PIDConfig DRIVE_MOTOR_PID_CONFIG = new PIDConfig(0.15 * 12.0); // TODO: not tuned at all
-    public static final PIDConfig ANGLE_MOTOR_PID_CONFIG = new PIDConfig(0.4 * 12.0); // multiply by 12.0 because
-    // voltage control is used
+    public static final PIDConfig ANGLE_MOTOR_PID_CONFIG = new PIDConfig(0.4 * 12.0);
 
     public static final FFConfig DRIVE_MOTOR_FF_CONFIG = new FFConfig(0.118, 2.617);
     public static final FFConfig ANGLE_MOTOR_FF_CONFIG = new FFConfig(0.132);

--- a/src/main/java/frc/robot/constants/Constants.java
+++ b/src/main/java/frc/robot/constants/Constants.java
@@ -54,6 +54,7 @@ public final class Constants {
 
     public static final double ENCODER_POSITION_OFFSET = 0.0;
     public static final double UP_ABSOLUTE_ENCODER_VALUE = 0.323;
+    public static final double UP_DEGREES = 114;
     public static final double STRAIGHT_ABSOLUTE_ENCODER_VALUE = 0.525;
     public static final double DOWN_ABSOLUTE_ENCODER_VALUE = 0.905;
 
@@ -65,11 +66,14 @@ public final class Constants {
     public static final double POWER_MOTOR_OUT_DIRECTION = 1.0;
 
     public static final double POWER_MOTOR_MAX_RPM = MotorFreeSpeeds.NEO_BRUSHLESS;
+    public static final double ROTATION_MOTOR_GEAR_RATIO = 60.0 / 1.0;
+    public static final double ROTATION_POSITION_CONVERSION_FACTOR = 360.0 / ROTATION_MOTOR_GEAR_RATIO;
 
     public static final CANSparkPIDFConfig POWER_MOTOR_SPARK_PIDF_CONFIG = new CANSparkPIDFConfig(0.000006, 0, 0,
         0, -1, 1);
     public static final CANSparkPIDFConfig ROTATION_MOTOR_SPARK_PIDF_CONFIG = new CANSparkPIDFConfig(0.000006, 0, 0,
-        0.0175, -1, 1);
+        0, -1, 1);
+    public static final PIDConfig ROTATION_MOTOR_PID_CONFIG = new PIDConfig(0.1 * 12.0, 0, 0);
     public static final FFConfig ROTATION_MOTOR_FF_CONFIG = new FFConfig(0.15, 12.0 / 5750.0);
     public static final FFConfig POWER_MOTOR_FF_CONFIG = new FFConfig(0.132, 12.0 / 5740.0);
     // 5740

--- a/src/main/java/frc/robot/constants/Constants.java
+++ b/src/main/java/frc/robot/constants/Constants.java
@@ -52,6 +52,7 @@ public final class Constants {
     public static final int ROTATION_THROUGH_BORE_ENCODER_DIO_PORT = 0;
     public static final int TOP_LIMIT_SWITCH_DIO_PORT = 4;
 
+    public static final double ENCODER_POSITION_OFFSET = 0.0;
     public static final double UP_ABSOLUTE_ENCODER_VALUE = 0.323;
     public static final double STRAIGHT_ABSOLUTE_ENCODER_VALUE = 0.525;
     public static final double DOWN_ABSOLUTE_ENCODER_VALUE = 0.905;

--- a/src/main/java/frc/robot/constants/Constants.java
+++ b/src/main/java/frc/robot/constants/Constants.java
@@ -52,11 +52,10 @@ public final class Constants {
     public static final int ROTATION_THROUGH_BORE_ENCODER_DIO_PORT = 0;
     public static final int TOP_LIMIT_SWITCH_DIO_PORT = 4;
 
-    public static final double ENCODER_POSITION_OFFSET = 0.0;
-    public static final double UP_ABSOLUTE_ENCODER_VALUE = 0.323;
-    public static final double UP_DEGREES = 114;
-    public static final double STRAIGHT_ABSOLUTE_ENCODER_VALUE = 0.525;
-    public static final double DOWN_ABSOLUTE_ENCODER_VALUE = 0.905;
+    public static final double ENCODER_POSITION_OFFSET = 0.323;
+    public static final double UP_DEGREES = 0;
+    public static final double STRAIGHT_DEGREES = 90;
+    public static final double DOWN_DEGREES = 213;
 
     // public static final int UP_DEGREES = 0;
     // public static final int DOWN_DEGREES = 180;
@@ -73,8 +72,8 @@ public final class Constants {
         0, -1, 1);
     public static final CANSparkPIDFConfig ROTATION_MOTOR_SPARK_PIDF_CONFIG = new CANSparkPIDFConfig(0.000006, 0, 0,
         0, -1, 1);
-    public static final PIDConfig ROTATION_MOTOR_PID_CONFIG = new PIDConfig(0.1 * 12.0, 0, 0);
-    public static final FFConfig ROTATION_MOTOR_FF_CONFIG = new FFConfig(0.15, 12.0 / 5750.0);
+    public static final PIDConfig ROTATION_MOTOR_PID_CONFIG = new PIDConfig(0.08 * 12.0, 0, 0);
+    public static final FFConfig ROTATION_MOTOR_FF_CONFIG = new FFConfig(0.2);
     public static final FFConfig POWER_MOTOR_FF_CONFIG = new FFConfig(0.132, 12.0 / 5740.0);
     // 5740
   }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeRotation.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeRotation.java
@@ -1,6 +1,7 @@
 package frc.robot.subsystems.intake;
 
 import com.revrobotics.CANSparkMax;
+import com.revrobotics.RelativeEncoder;
 import com.revrobotics.CANSparkBase.ControlType;
 import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkLowLevel.MotorType;
@@ -15,6 +16,7 @@ import frc.robot.constants.Constants;
 
 public class IntakeRotation extends SubsystemBase {
     private final CANSparkMax motor;
+    private final RelativeEncoder encoder;
 
     private final DutyCycleEncoder throughBoreEncoder;
     private final DigitalInput topLimitSwitch;
@@ -25,11 +27,17 @@ public class IntakeRotation extends SubsystemBase {
         this.motor = new PIDCANSparkMax(Constants.Intake.ROTATION_MOTOR_ID, MotorType.kBrushless,
                 IdleMode.kBrake, false, Constants.Intake.ROTATION_MOTOR_SPARK_PIDF_CONFIG);
 
+        this.encoder = this.motor.getEncoder();
+        this.encoder.setPositionConversionFactor(360);
+
         this.throughBoreEncoder = new DutyCycleEncoder(Constants.Intake.ROTATION_THROUGH_BORE_ENCODER_DIO_PORT);
+        this.throughBoreEncoder.setDistancePerRotation(360);
 
         this.topLimitSwitch = new DigitalInput(Constants.Intake.TOP_LIMIT_SWITCH_DIO_PORT);
 
         this.motorFeedForward = new ConfiguredSimpleMotorFeedforward(Constants.Intake.ROTATION_MOTOR_FF_CONFIG);
+
+        this.encoder.setPosition(this.throughBoreEncoder.getAbsolutePosition());
     }
 
     @Override
@@ -43,6 +51,10 @@ public class IntakeRotation extends SubsystemBase {
     public void setMotorVelocitySetpoint(double velocity) {
         this.motor.getPIDController().setReference(this.motorFeedForward.calculate(velocity),
                 ControlType.kVoltage);
+    }
+
+    public void setMotorPositionSetpoint(double position) {
+        this.motor.getPIDController().setReference(position, ControlType.kPosition);
     }
 
     // public void setMotorVoltageSetpoint(double voltage) {

--- a/src/main/java/frc/robot/subsystems/intake/IntakeRotation.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeRotation.java
@@ -27,17 +27,18 @@ public class IntakeRotation extends SubsystemBase {
 
     public IntakeRotation() {
         this.motor = new PIDCANSparkMax(Constants.Intake.ROTATION_MOTOR_ID, MotorType.kBrushless,
-                IdleMode.kBrake, false, Constants.Intake.ROTATION_MOTOR_SPARK_PIDF_CONFIG);
+                IdleMode.kBrake, true, Constants.Intake.ROTATION_MOTOR_SPARK_PIDF_CONFIG);
 
         this.encoder = this.motor.getEncoder();
         // this.encoder.setPositionConversionFactor(360);
 
         this.throughBoreEncoder = new DutyCycleEncoder(Constants.Intake.ROTATION_THROUGH_BORE_ENCODER_DIO_PORT);
-        this.throughBoreEncoder.setPositionOffset(0.905);
+        this.throughBoreEncoder.setPositionOffset(0.320);
 
         this.topLimitSwitch = new DigitalInput(Constants.Intake.TOP_LIMIT_SWITCH_DIO_PORT);
 
         this.PIDController = new ConfiguredPIDController(Constants.Intake.ROTATION_MOTOR_PID_CONFIG);
+        this.PIDController.setTolerance(5);
 
         this.motorFeedForward = new ConfiguredSimpleMotorFeedforward(Constants.Intake.ROTATION_MOTOR_FF_CONFIG);
 
@@ -47,18 +48,21 @@ public class IntakeRotation extends SubsystemBase {
 
     @Override
     public void periodic() {
-        SmartDashboard.putNumber("Intake Relative Angle",
-                this.encoder.getPosition() * Constants.Intake.ROTATION_POSITION_CONVERSION_FACTOR);
+        // SmartDashboard.putNumber("Intake Relative Angle",
+        // this.encoder.getPosition() *
+        // Constants.Intake.ROTATION_POSITION_CONVERSION_FACTOR);
         // SmartDashboard.putNumber("Intake Through Bore Angle",
         // this.throughBoreEncoder.getAbsolutePosition());
-        SmartDashboard.putNumber("Intake Through Bore Angle", this.throughBoreEncoder.getAbsolutePosition() * 360);
-
+        SmartDashboard.putNumber("Intake Through Bore Angle",
+                (this.throughBoreEncoder.getAbsolutePosition() - this.throughBoreEncoder.getPositionOffset()) * 360.0);
+        SmartDashboard.putNumber("raw abs pos", this.throughBoreEncoder.getAbsolutePosition());
         SmartDashboard.putNumber("Intake Rotation Speed", this.motor.getEncoder().getVelocity());
     }
 
     public void setAngle(double angle) {
         double voltage = this.PIDController.calculate(this.getAngle(), angle);
         voltage += this.motorFeedForward.calculate(0);
+        System.out.println(voltage);
         this.motor.setVoltage(voltage);
     }
 
@@ -72,7 +76,7 @@ public class IntakeRotation extends SubsystemBase {
     // }
 
     public double getAngle() {
-        return this.throughBoreEncoder.getAbsolutePosition() * 360.0;
+        return (this.throughBoreEncoder.getAbsolutePosition() - this.throughBoreEncoder.getPositionOffset()) * 360.0;
     }
 
     public void stopMotor() {

--- a/src/main/java/frc/robot/subsystems/intake/IntakeRotation.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeRotation.java
@@ -12,70 +12,58 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.lib.drivers.ConfiguredPIDController;
 import frc.lib.drivers.ConfiguredSimpleMotorFeedforward;
-import frc.lib.drivers.uppermech.PIDCANSparkMax;
+import frc.lib.drivers.uppermech.ConfiguredCANSparkMax;
 import frc.robot.constants.Constants;
 
 public class IntakeRotation extends SubsystemBase {
     private final CANSparkMax motor;
-    private final RelativeEncoder encoder;
 
     private final DutyCycleEncoder throughBoreEncoder;
+
     private final DigitalInput topLimitSwitch;
 
     private final ConfiguredPIDController PIDController;
     private final ConfiguredSimpleMotorFeedforward motorFeedForward;
 
     public IntakeRotation() {
-        this.motor = new PIDCANSparkMax(Constants.Intake.ROTATION_MOTOR_ID, MotorType.kBrushless,
-                IdleMode.kBrake, true, Constants.Intake.ROTATION_MOTOR_SPARK_PIDF_CONFIG);
-
-        this.encoder = this.motor.getEncoder();
-        // this.encoder.setPositionConversionFactor(360);
+        this.motor = new ConfiguredCANSparkMax(Constants.Intake.ROTATION_MOTOR_ID, MotorType.kBrushless,
+                IdleMode.kBrake, true);
 
         this.throughBoreEncoder = new DutyCycleEncoder(Constants.Intake.ROTATION_THROUGH_BORE_ENCODER_DIO_PORT);
-        this.throughBoreEncoder.setPositionOffset(0.320);
+        this.throughBoreEncoder.setPositionOffset(Constants.Intake.ROTATION_THROUGH_BORE_ENCODER_POSITION_OFFSET);
 
         this.topLimitSwitch = new DigitalInput(Constants.Intake.TOP_LIMIT_SWITCH_DIO_PORT);
 
         this.PIDController = new ConfiguredPIDController(Constants.Intake.ROTATION_MOTOR_PID_CONFIG);
         this.PIDController.setTolerance(5);
-
         this.motorFeedForward = new ConfiguredSimpleMotorFeedforward(Constants.Intake.ROTATION_MOTOR_FF_CONFIG);
-
-        // this.encoder.setPosition(this.throughBoreEncoder.getAbsolutePosition() *
-        // 360.0);
     }
 
     @Override
     public void periodic() {
-        // SmartDashboard.putNumber("Intake Relative Angle",
-        // this.encoder.getPosition() *
-        // Constants.Intake.ROTATION_POSITION_CONVERSION_FACTOR);
-        // SmartDashboard.putNumber("Intake Through Bore Angle",
-        // this.throughBoreEncoder.getAbsolutePosition());
-        SmartDashboard.putNumber("Intake Through Bore Angle",
-                (this.throughBoreEncoder.getAbsolutePosition() - this.throughBoreEncoder.getPositionOffset()) * 360.0);
-        SmartDashboard.putNumber("raw abs pos", this.throughBoreEncoder.getAbsolutePosition());
-        SmartDashboard.putNumber("Intake Rotation Speed", this.motor.getEncoder().getVelocity());
+        SmartDashboard.putNumber("Intake Through Bore Angle", this.getAngle());
     }
 
+    /**
+     * Sets the angle of the intake using PID closed loop control
+     * 
+     * @param angle the desired angle in degrees
+     */
     public void setAngle(double angle) {
         double voltage = this.PIDController.calculate(this.getAngle(), angle);
+        // 0 velocity because we do not care about the velocity of the rotation motor,
+        // we just want to get it to a specific angle
         voltage += this.motorFeedForward.calculate(0);
         System.out.println(voltage);
         this.motor.setVoltage(voltage);
     }
 
-    public void setMotorPositionSetpoint(double position) {
-        this.motor.getPIDController().setReference(position, ControlType.kPosition);
-    }
-
-    // public void setMotorVoltageSetpoint(double voltage) {
-    // this.rotationMotor.getPIDController().setReference(voltage,
-    // ControlType.kVoltage);
-    // }
-
+    /**
+     * 
+     * @return the angle of the intake in degrees
+     */
     public double getAngle() {
+        // https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/wpilibj/DutyCycleEncoder.html#getAbsolutePosition()
         return (this.throughBoreEncoder.getAbsolutePosition() - this.throughBoreEncoder.getPositionOffset()) * 360.0;
     }
 
@@ -83,6 +71,10 @@ public class IntakeRotation extends SubsystemBase {
         this.motor.stopMotor();
     }
 
+    /**
+     * 
+     * @return whether the intake rotation is within 5 degrees of the desired angle
+     */
     public boolean atSetpoint() {
         return this.PIDController.atSetpoint();
     }


### PR DESCRIPTION
# intake rotation is now done using PID control
this is an important step, as it now means we know how to run a rotation arm to an angle setpoint in degrees, which we need to do later to set the shooter to an angle calculated using the limelight/apriltag and trig

improvements:
- intake rotation can be specified using an angle in degrees, so there is meaning to the number instead of it just being a magic encoder number
- intake power in is run for 0.1 seconds after the note is detected to ensure the note gets positioned correctly physically
- created a PID control to use for the rotation motor
  - the intake should not bang into the robot or the floor anymore is a setpoint the intake it already at is commanded
- way smoother intake rotation! https://github.com/RambotsTeam1350/CRESCENDO-2024/assets/19848162/9e1c35e9-cb5e-45b1-ac74-f74e49a4982c
